### PR TITLE
Updates!

### DIFF
--- a/image-processing/UI.py
+++ b/image-processing/UI.py
@@ -7,14 +7,12 @@ import numpy as np
 import os.path
 from pathlib import Path
 from linefinder import linefinder
-'''
-make it so the path is customisable without having to change it in the code
-note to self - if some values need to be changed depending on the sample, could send them different variation of the code to be ran for different samples if can't combine in to one 
-'''
+
+
 while True:
     response = input('please specify the path for where this code is saved, to where the sample scans have been saved. If unsure what is meant by this, please respond "help":  ')
     if (response == 'help') or (response == 'HELP') or (response == 'Help'):
-        print(r'Using file explorer on Widnows, open the folder containing the scans. In the naviagation bar at the top, rigt click on the name of the folder, and then click "copy address as text"\n' 'the copied text should look something like: "D:\Tom\Documents\Physics\PHYS355\phys355_code\scans_75dpi"' )
+        print('Using file explorer on Widnows, open the folder containing the scans. In the naviagation bar at the top, rigt click on the name of the folder, and then click "copy address as text"\n' 'the copied text should look something like: "D:\Tom\Documents\Physics\PHYS355\phys355_code\scans_75dpi"' )
         continue
     if not Path(response).is_dir():
         print('path was not recognised, please try again: ')
@@ -25,9 +23,22 @@ while True:
 
 paths = []
 scans = [] 
-scans_folder = Path(path_to_folder) #relative path to the file with the scans. Quite simple for my current setup but may not always be the case
+scans_folder = Path(path_to_folder) 
 np_array_scans = []
 while True:
+    
+    sampleType_imp = input('What type of sample would you like to test? \n Enter 1 for Carbon, 2 for Metal-Coated Carbon... \n NOTE: only what type of sample can be tested at once, in order to test multiple types of sample, please re-run the program for each type \n Type of Sample:  ')
+
+    try:
+        sampleType = int(sampleType_imp)
+    except:
+        print('something went wrong. Please try again')
+        continue
+
+    if sampleType > 2: #CHANGE THIS WHEN OTHER SAMPLE TYPES ARE ADDED!!!!!!!!
+        print('Sorry, number did not correspond to a known sample type, please try again')
+        continue
+
     print('please ensure samples are scanned at 75dpi')
     new_files = input('enter new files, or find lines in previously saved files? Respond with either new, or saved: ').lower()
 
@@ -42,6 +53,9 @@ while True:
             file = scans_folder / filename
             if not file.exists():
                 print('Sorry, this file does not exist, please retype including spaces, and the file suffix, e.g. .jpeg ')
+                kill = input('if you have already entered all of your files, and the original number you typed was too high, please type quit now: ').lower
+                if kill == 'quit':
+                    break
                 continue
             else:
                 scans.append(file)
@@ -67,29 +81,41 @@ while True:
                     finder = linefinder(original, sigma, row)
                     if view_plot == 'yes':
                         print('Result for Sample {}'.format(scans[scan].stem))
-                        finder.severity(4,False)
+                        if sampleType == 1:
+                            finder.severity_carbon(4,False)
+                        if sampleType == 2:
+                            finder.severity_metal_coated(6)
                         name = str(scans[scan].stem)
                         finder.plot_nice(name = name)
                     elif view_plot == 'no':
                         print('Result for Sample {}'.format(scans[scan].stem))
-                        finder.severity(4,False)
+                        if sampleType == 1:
+                            finder.severity_carbon(4,False)
+                        if sampleType == 2:
+                            finder.severity_metal_coated(6)
                 if set_paramaters == 'no':
-                    blur_imp = input('Set sigma value for gaussian blur:    ')
+                    blur_imp = input('Set sigma value for gaussian blur: ')
                     blur = int(blur_imp)
-                    row_imp = input('Set row number that is checked:     ')
+                    row_imp = input('Set row number that is checked: ')
                     row = int(row_imp)
-                    baseline_imp = input('How severe do lines need to be in order to fail the sample, out of 10 - Note: 8 out of 10 is the reccommended value:       ')
+                    baseline_imp = input('How severe do lines need to be in order to fail the sample ? \n Note: 8  is the reccommended value for Sample Type 1 \n 12 is the recommended value for Sample Type 2 \n Enter Value:  ')
                     baseline = int(baseline_imp)/2
                     original = np_array_scans[scan]
                     finder = linefinder(original, blur, row)
                     if view_plot == 'yes':
                         print('Result for Sample:  {}'.format(scans[scan].stem))
-                        finder.severity(baseline,False) #still false so that plot_nice can be used
+                        if sampleType == 1:
+                            finder.severity_carbon(baseline,False) #still false so that plot_nice can be used
+                        if sampleType ==2:
+                            finder.severity_metal_coated(6)
                         name = str(scans[scan].stem)
                         finder.plot_nice(name)
                     elif view_plot == 'no':
                         print('Result for Sample: {}'.format(scans[scan].stem))
-                        finder.severity(baseline,False)
+                        if sampleType == 1:
+                            finder.severity_carbon(baseline,False)
+                        if sampleType == 2:
+                            finder.severity_metal_coated(baseline)
         if test_now == 'no':
 
             print('files have been saved for later use')
@@ -128,12 +154,20 @@ while True:
                     finder = linefinder(original, sigma, row)
                     if view_plot == 'yes':
                         print('Result for Sample: {}'.format(paths[scan].stem))
-                        finder.severity(4,False)
+                        if sampleType == 1:
+                            finder.severity_carbon(4,False)
+                        if sampleType == 2:
+                            finder.severity_metal_coated(6)
+
                         name = str(paths[scan].stem)
                         finder.plot_nice(name)
                     elif view_plot == 'no':
                         print('Result for Sample:  {}'.format(paths[scan].stem))
-                        finder.severity(4,False)
+                        if sampleType == 1:
+                            finder.severity_carbon(4,False)
+                        if sampleType == 2:
+                            finder.severity_metal_coated(6)
+
             if set_paramaters == 'no':
                     '''
                     If set paramaters is no, then the user wants to set there own custom parameters. These parameters are the sigma value for the guassian blur - how blurred the sample gets:
@@ -145,13 +179,16 @@ while True:
                     blur = int(blur_imp)
                     row_imp = input('Set row number that is checked ')
                     row = int(row_imp)
-                    baseline_imp = input('How severe do lines need to be to fail the sample, out of 10 - Note: 8 out of 10 is the reccommended value ') 
+                    baseline_imp = input('How severe do lines need to be to fail the sample? \n Note: 8  is the reccommended value for Sample Type 1 \n 12 is the recommended value for Sample Type 2 \n Enter Value: ') 
                     baseline = int(baseline_imp)/2
                     original = scans[scan]
                     finder = linefinder(original, blur, row)
                     if view_plot == 'yes':
                         print('Result for Sample:  {}'.format(paths[scan].stem))
-                        finder.severity(baseline,False)
+                        if sampleType == 1:
+                            finder.severity_carbon(baseline,False)
+                        if sampleType == 2:
+                            finder.severity_metal_coated(baseline)
                         name = str(paths[scan].stem)
                         finder.plot_nice(name)
                     elif view_plot == 'no':

--- a/image-processing/linefinder.py
+++ b/image-processing/linefinder.py
@@ -15,12 +15,10 @@ ADD INS - ADD IN A REPATED FOR A DIFFERENT ROW, AND THEN CAN CHECK THE EXISTENCE
 class linefinder:
     '''
     A class of different methods to hopefully find the machine direction lines in a sample nonwoven.
-
         Inputs: 
         Original - greyscale sample, should be a np array
         sigma - the sigma value for the Gaussian Blur 
         row - the row in which sample is tested for lines -> this leads to a large assumption that the sample is uniform, and may need to change 
-
         Outputs vary on function, however the view_plot input is seen in all class functions, if this is set to True, then a plot will be displayed 
     '''
     def __init__(self, original, sigma, row):
@@ -31,9 +29,7 @@ class linefinder:
         Original - greyscale sample, should be a np array
         sigma - the sigma value for the Gaussian Blur 
         row - the row in which sample is tested for lines -> this leads to a large assumption that the sample is uniform, and may need to change 
-
         A ValueError is raised if a row is selected which is out of the bounds of the sample
-
         '''
 
 
@@ -47,14 +43,11 @@ class linefinder:
     def blur_sample_gauss(self, view_plot):
         '''
         Puts the original sample through a Guassian blur. This is used to reduce noise in the sample
-
         Inputs: 
         self 
         view_plot - set True if the output plot is to be viewed 
-
         Outputs:
         A figure showing the the original sample, as well as the blurred sample, and graphs of pixel value against number for both the original and the blurred sample, along the row specified 
-
         returns:
         The np array containing the blurred sample, which is used throughout the rest of the class 
         '''
@@ -80,154 +73,16 @@ class linefinder:
             plt.show()
         return sample_blur
 
-    def find_lines_gblur(self, view_plot):
-        '''
-        After the sample has gone through a Gaussian Blur, this then uses argrelextrema to find local minima along the pixel values for a row. These minima are assumed to be 
-        due to the prescence of lines.
-        Inputs: 
-        self
-        view_plot - set as true if wish to view the output plot 
-
-        Outputs:
-        Figure showing the blurred sample, pixel values against position for the row selected, and the detected lines on the original sample from the peaks of the guassian blur 
-
-        returns:
-        returns the positions of the lines - the positions of local minima along one row of pixels 
-        ''' 
-        x = linefinder.blur_sample_gauss(self,view_plot = False)
-        max_positions = argrelextrema(x[self.row],np.greater)
-        
-        if view_plot == True:
-            fig, ax = plt.subplots(ncols=3, nrows=1)
-            fig.suptitle('Detecting lines though Guassian Blur')
-            ax[0].imshow(x, cmap='gray')
-            ax[0].set(xlabel='', ylabel='', title = 'Blurred Sample, sigma = {}'.format(self.sigma))
-
-            ax[1].plot(np.arange(0,np.size(x[self.row]), 1), x[self.row])
-            ax[1].set(xlabel='', ylabel='', title = 'Values along 200th row \n for the blurred sample')
-
-            ax[2].imshow(self.original, cmap='gray')
-            ax[2].vlines(max_positions, color = 'red', ymin=0, ymax=500, linewidth=1)
-            ax[2].set(xlabel='', ylabel='', title='Detected lines')
-
-            plt.show()
-        return max_positions
-
-    def FT_blur(self, view_plot=True):
-        '''
-        Takes the Fourier Transform of one row of pixels, hoping to clarify the existence of periodic behaviour. 
-        Inputs: 
-        self
-        view_plot - set as true if wish to view output plot
-
-        Outputs:
-        Figure showing blurred sample, pixel values for the selected row and Fourier transform of the pixel value on that rows 
-
-        returns:
-        array of the fourier transform of the chosen row of the blurred sample 
-        '''
-        x = linefinder.blur_sample_gauss(self, view_plot=False)
-        sample_FT = fftpack.fft(x[self.row])
-        
-        FTabs = np.abs(sample_FT)
-
-        if view_plot == True:
-            fig, ax = plt.subplots(ncols=3, nrows=1)
-            fig.suptitle('Fourier Transform after Blurring')
-            ax[0].imshow(x, cmap='gray')
-            ax[0].set(xlabel='', ylabel='', title = 'Blurred Sample, sigma = {}'.format(self.sigma))
-
-            ax[1].plot(np.arange(0,np.size(x[self.row]), 1), x[self.row])
-            ax[1].set(xlabel='', ylabel='', title = 'Values along row number {} \n for the blurred sample'.format(self.row))
-
-            ax[2].plot(np.arange(0,np.size(FTabs)-1, 1), FTabs[1:])
-            ax[2].set(xlabel='', ylabel='', title='FT transform of 200th row of values')
-
-            plt.show()
-        return sample_FT
-
-
-    def find_lines_fourier(self, view_plot=True):
-        '''
-        Uses the Fourier transform to find lines by using the argrelextrema package to find local maxima from within the Fourier Transform
-        Inputs:
-        self
-        view_plot - set as true if wish to view output plot
-
-        Outputs:
-        Figure showing the blurred sample, the pixel values along the chosen row, and the lines detected - the positions of the local maxima of the fourier transform
-
-        Returns:
-        the line positions according to the local maxima of the Fourier Transform
-        
-
-        '''
-        x = linefinder.blur_sample_gauss(self,False)
-        y = linefinder.FT_blur(self,False)
-        max_positions = argrelextrema(np.real(y), np.greater)
-        
-        if view_plot == True:
-            fig, ax = plt.subplots(ncols=3, nrows=1)
-            fig.suptitle('Detecting lines though Fourier Transform')
-            ax[0].imshow(x, cmap='gray')
-            ax[0].set(xlabel='', ylabel='', title = 'Blurred Sample, sigma = {}'.format(self.sigma))
-
-            ax[1].plot(np.arange(0,np.size(x[self.row]), 1), x[self.row])
-            ax[1].set(xlabel='', ylabel='', title = 'Values along row number {} \n for the blurred sample'.format(self.row))
-
-            ax[2].imshow(self.original, cmap='gray')
-            ax[2].vlines(max_positions, color = 'red', ymin=0, ymax=500, linewidth=1)
-            ax[2].set(xlabel='', ylabel='', title='Detected lines')
-
-            plt.show()
-        
-        return max_positions
-
-    def cwt(self, view_plot=True):
-        '''
-        Uses a wavelet transform to try and find peaks - the original data is convolved with wavelets, the widths of this are an input of the find_peaks_cwt 
-        MORE RESEARCH NEEDED INTO THE EFFECT OF CHANGING WAVELET WIDTHS
-
-        Inputs:
-        self
-        view_plot - set to true to view the output figure
-
-        Outputs:
-         Figure showing the blurred sample, the pixel values along the chosen row, and the lines detected - the positions of peaks along that row
-
-        '''
-        x = linefinder.blur_sample_gauss(self,False)
-        widths = (np.arange(1,np.size(x[self.row])+1, 1))
-        peak_positions = find_peaks_cwt(x[self.row], widths)
-
-        if view_plot == True:
-            fig, ax = plt.subplots(ncols=3, nrows=1)
-            fig.suptitle('Detecting lines though CWT transform')
-            ax[0].imshow(x, cmap='gray')
-            ax[0].set(xlabel='', ylabel='', title = 'Blurred Sample, sigma = {}'.format(self.sigma))
-
-            ax[1].plot(np.arange(0,np.size(x[self.row]), 1), x[self.row])
-            ax[1].set(xlabel='', ylabel='', title = 'Values along row number {} \n for the blurred sample'.format(self.row))
-
-            ax[2].imshow(self.original, cmap='gray')
-            ax[2].vlines(peak_positions, color = 'red', ymin=0, ymax=500, linewidth=1)
-            ax[2].set(xlabel='', ylabel='', title='Detected lines')
-
-            plt.show()
         
     def scipy_peaks(self, view_plot=True):
         '''
         finds pixel value peaks along the chosen row, using the scipy find_peaks function
-
         Inputs:
         self
         view_plot - set to true in order to see the output plot 
-
         Outputs:
         figure showing the blurred sample, the pixel values along that row, and the detected lines from the peaks of that row, shown on the original sample     
-
         Returns the positions of the peaks along the chosen row 
-
         '''
         x = linefinder.blur_sample_gauss(self, False)
         peak_positions = find_peaks(x[self.row])
@@ -253,11 +108,9 @@ class linefinder:
     def find_prominences(self, view_plot = True):
         '''
         finds the prominence of the peaks found by the scipy_peaks method
-
         Inputs:
         self
         view_plot - set to true in order to see the output plot
-
         Outputs:
         a figure showing the blurred sample, the pixel values along the chosen rows, and the pixel value with marked peaks and lines drawn to show prominence 
         '''
@@ -288,19 +141,15 @@ class linefinder:
     --- need to raise an error if inputs are neither integers or booleans ---
     find lines within the sample, excluding some of the peaks from the original find peaks method, in an attempt to make sure that peaks aren't found when there are no visible peaks --- 
     in the sample 
-
     Inputs:
     self
     view_plot - set to true to view the output plot 
     distance - the mninimum distance between peaks. Must be a boolean or an integer - if integer, this is used as the minimum distance, if boolean, 100th of the total width is used 
     min_prominences - the min prominence needed for a peak to be counted. if an integer this is used, if a boolean then any prominence greater or equal to the mean is used 
-
     There must be at least one value for either distance or min_prominence, or ValueError will be raised 
-
     outputs: 
     a figure showing the blurred sample, the pixel values along the chosen rows, and the pixel value with marked peaks and lines drawn to show prominence, and the lines detected 
     by this method on top of the original sample 
-
     
         '''
         blurred = linefinder.blur_sample_gauss(self,False)
@@ -313,7 +162,7 @@ class linefinder:
         min_distance = None 
 
         if isinstance(min_promineneces, bool):
-            if not min_promineneces: #if no value is given, then it takes prominences that are greater than the mean only 
+            if min_promineneces: #if no value is given, then it takes prominences that are greater than the mean only 
             #it is probably sensible to also add a minimum prominence here, but more research is needed to find what this minimum should be 
                 mean_prominence = np.mean(prominences_no_exclusions)
                 prominences = prominences_no_exclusions[prominences_no_exclusions>=mean_prominence]
@@ -324,7 +173,7 @@ class linefinder:
             prominences = min_promineneces
 
         if isinstance(distance, bool):
-            if not distance:
+            if distance:
                 min_distance = len(blurred[0])/100 #if no value is given, defaults to a hundredth of the total width of the sample 
 
         elif isinstance(distance, int):
@@ -369,14 +218,13 @@ class linefinder:
 
 
 
-    def severity(self,baseline,view_plot= True):
+    def severity_carbon(self,baseline,view_plot= True):
         '''
+        determine the severity of machine direction lines in a sample of carbon veil nonwoven
         Inputs:
         self
         Baseline - this is the mark that if the average prominence is above this, then the sample has failed. More testing needs to be done to determine exactly what this value should be
         view_plot - should be set to true in order to display a figure showing the sample, the pixel values, and the detected lines 
-
-
         '''
         x = linefinder.blur_sample_gauss(self,False)
         y = linefinder.scipy_peaks(self,False)
@@ -389,17 +237,36 @@ class linefinder:
         else:
             print('Sample has passed. Severity of lines is {}, which gives the sample a {} out of 10'.format(mean_prominence, inv_out_of_10))
         if view_plot == True:
-            linefinder.find_lines_with_exclusions(self,True, True, 3) # the 7 here is just what appears to be the best from testing, it's not been calculated as such
+            linefinder.find_lines_with_exclusions(self,True, True, 7) # the 7 here is just what appears to be the best from testing, it's not been calculated as such
+        return inv_out_of_10
 
-    
+    def severity_metal_coated(self, baseline):
+
+        '''
+        determine the severity of machine direction lines in a sample of metal coated carbon viel nonwoven
+        Inputs:
+        self
+        Baseline - this is the mark that if the average prominence is above this, then the sample has failed. More testing needs to be done to determine exactly what this value should be
+
+        '''
+        x = linefinder.blur_sample_gauss(self,False)
+        y = linefinder.scipy_peaks(self,False)
+        prominences = peak_prominences(x[self.row],y)[0]
+        mean_prominence = np.mean(prominences)
+        out_of_10 = ((mean_prominence - 4.00)/(10.9-4.00)) * 10
+        inv_out_of_10 = 10 - out_of_10
+        if mean_prominence >= baseline:
+            print('Sample has failed, lines are too prominent for sample to be used \n Severity of lines is {}, which gives the sample a {} out of 10'.format(mean_prominence, inv_out_of_10))
+        else:
+            print('Sample has passed. Severity of lines is {}, which gives the sample a {} out of 10'.format(mean_prominence, inv_out_of_10))
+
     def plot_nice(self, name):
         '''
         Inputs: Self
-
         Outputs: outputs a cleaner looking plot than what is given by the other functions
         '''
         blurred = linefinder.blur_sample_gauss(self,False)
-        x = linefinder.find_lines_with_exclusions(self,view_plot= False, distance=10, min_promineneces=4)
+        x = linefinder.find_lines_with_exclusions(self,view_plot= False, distance=10, min_promineneces=6)
 
 
 
@@ -413,7 +280,3 @@ class linefinder:
         ax[1].vlines(x=x, color = 'red', ymin=0, ymax=len(blurred), linewidth=1)
         ax[1].set(xlabel='', ylabel='', title='Detected lines')
         plt.show()
-
-
-
-


### PR DESCRIPTION
- works for multiple file types 
- excess code in linefinder was cut 
- try except statements, as well as various other loop breaks so that it's less likely the whole thing breaks when something is typed in wrong